### PR TITLE
This fixes the docker sha256 mismatch for docker 1.5.0

### DIFF
--- a/src/registry/api/images.go
+++ b/src/registry/api/images.go
@@ -67,6 +67,7 @@ func (a *RegistryAPI) PutImageLayerHandler(w http.ResponseWriter, r *http.Reques
 	// storage and checksum each individual file within it (and checksum those checksums with the jsonContent)
 	sha256Writer := sha256.New()
 	sha256Writer.Write(jsonContent)
+	sha256Writer.Write([]byte("\n"))
 	teeReader := io.TeeReader(r.Body, sha256Writer)
 	// this will create the checksums for a tar and the json for tar file info
 	tarInfo := layers.NewTarInfo()


### PR DESCRIPTION
Should alleviate the mismatches for docker 1.5.0; likely to effect 1.4.0 as well.